### PR TITLE
Properly fix https://github.com/ahlechandre/mdl-stepper/issues/11

### DIFF
--- a/src/stepper/stepper.js
+++ b/src/stepper/stepper.js
@@ -356,7 +356,7 @@
       // Prevents the step label to scrolling out of user view on Google Chrome.
       // More details here: <https://github.com/ahlechandre/mdl-stepper/issues/11 />.
       stepElements[i].addEventListener('scroll', function (event) {
-        event.target.scrollTo(0, 0);
+        event.target.scrollTop = 0;
       });
     }
     total = collection.length;


### PR DESCRIPTION
Original issue with label scrolling is still present, as the original solution used a jquery function scrollTo() instead of assigning scrolltop.
