### PR TITLE
Used CustomEvent instead of Event

### DIFF
--- a/src/stepper/stepper.js
+++ b/src/stepper/stepper.js
@@ -80,7 +80,7 @@
   MaterialStepper.prototype.defineCustomEvent = function (evtName, bubble, cancel) {
     var ev;
     if ('CustomEvent' in window && typeof window.CustomEvent === 'function') {
-      ev = new Event(evtName, {
+      ev = new CustomEvent(evtName, {
         bubbles: bubble,
         cancelable: cancel
       });


### PR DESCRIPTION
We have a nice condition on line 82, which checks for `CustomEvent` presence. Instead of `CustomEvent` we create `Event` object? Doesn't make sense. MDL in [source code](https://github.com/google/material-design-lite/blob/mdl-1.x/src/mdlComponentHandler.js#L152) uses `CustomEvent` as well. I also found this to be broken combined with Mootools.